### PR TITLE
Breaking parse_command into preprocessor and parser classes

### DIFF
--- a/pag/parser.py
+++ b/pag/parser.py
@@ -2,6 +2,39 @@
 
 from pag import words as pag_words
 
+class Preprocessor:
+    def __init__(self):
+
+        self._directions = pag_words.directions
+
+
+    def supplement_words(self, words=None):
+        """
+        """
+
+        if 'directions' in words:
+            self._directions = {**self._verbs, **words['directions']}
+
+
+    def prep(self, command):
+        """
+        Pre-process a command.
+        """
+
+        toreturn = command.lower().strip()
+
+        # See if command is only a direction
+        for i in self._directions:
+            if command.strip() == i:
+                # Return Verb, Noun
+                toreturn = "go {}".format(i)
+            else:
+                for syn in self._directions[i]:
+                    if command.strip() == syn:
+                        toreturn = "go {}".format(i)
+
+        return toreturn
+
 
 class Parser:
     def __init__(self):
@@ -32,7 +65,7 @@ class Parser:
 
     def eat_verb(self, command):
         """
-        Try to consome a verb.
+        Try to consume a verb.
         """
 
     def eat_noun(self, command, typed_verb):
@@ -53,7 +86,11 @@ class Parser:
 
     def parse(self, command):
 
-        command = command.lower()
+
+        prep = Preprocessor()
+
+        command = prep.prep(command)
+
         # remove extra words
         split_cmd = command.split(' ')
         removing = [word for word in split_cmd if word in self._extras]
@@ -82,15 +119,6 @@ class Parser:
         if verb != '':
             parsed_command.append(verb)
         else:
-            # See if command is only a direction
-            for i in self._directions:
-                if command.strip() == i:
-                    # Return Verb, Noun
-                    return [None, i]
-                else:
-                    for syn in self._directions[i]:
-                        if command.strip() == syn:
-                            return [None, i]
             print('What?')
             return
 
@@ -108,7 +136,6 @@ class Parser:
                     print(f'I don\'t understand the noun "{rest_of_command}."')
                     return
 
-        print(parsed_command)
         return parsed_command
 
 

--- a/pag/parser.py
+++ b/pag/parser.py
@@ -26,24 +26,29 @@ class Preprocessor:
         Pre-process a command.
         """
 
+        # Normalise whitespaces
         toreturn = command.lower().strip()
+        if len(toreturn) == 0:
+            return ""
+
+        tokens = toreturn.split()
+        tokens = [t for t in tokens if len(t) > 0]
 
         # See if command is only a direction
         for i in self._directions:
             if command.strip() == i:
                 # Return Verb, Noun
-                toreturn = "go {}".format(i)
+                tokens = ["go", i]
             else:
                 for syn in self._directions[i]:
                     if command.strip() == syn:
-                        toreturn = "go {}".format(i)
+                        tokens = ["go", i]
 
         # remove extra words
-        split_cmd = toreturn.split(' ')
-        removing = [word for word in split_cmd if word in self._extras]
+        removing = [word for word in tokens if word in self._extras]
         for word in removing:
-            split_cmd.remove(word)
-        toreturn = ' '.join(split_cmd)
+            tokens.remove(word)
+        toreturn = ' '.join(tokens)
 
         return toreturn
 

--- a/pag/parser.py
+++ b/pag/parser.py
@@ -30,6 +30,27 @@ class Parser:
                 self._directions = {**self._verbs, **words['directions']}
 
 
+    def eat_verb(self, command):
+        """
+        Try to consome a verb.
+        """
+
+    def eat_noun(self, command, typed_verb):
+        """
+        Try to consume a noun.
+        """
+        rest_of_command = command.split(typed_verb + ' ')[1]
+        for i in {**self._nouns, **self._directions}:
+            if rest_of_command == i:
+                noun = i
+                return noun
+
+            else:
+                for syn in {**self._nouns, **self._directions}[i]:
+                    if rest_of_command == syn:
+                        noun = i
+                        return noun
+
     def parse(self, command):
 
         command = command.lower()
@@ -41,7 +62,7 @@ class Parser:
         command = ' '.join(split_cmd)
         parsed_command = []
         # command must start with a verb
-        no_noun = False
+        expect_noun = True
         verb = ''
         typed_verb = ''
         for i in self._verbs:
@@ -49,7 +70,7 @@ class Parser:
                 verb = i
                 typed_verb = i
             if command.strip() == i:
-                no_noun = True
+                expect_noun = False
             else:
                 for syn in self._verbs[i]:
                     if (command.startswith(syn + ' ') or
@@ -57,7 +78,7 @@ class Parser:
                         verb = i
                         typed_verb = syn
                     if command.strip() == syn:
-                        no_noun = True
+                        expect_noun = False
         if verb != '':
             parsed_command.append(verb)
         else:
@@ -72,24 +93,22 @@ class Parser:
                             return [None, i]
             print('What?')
             return
+
+
         # next is a noun
         noun = ''
         rest_of_command = ''
-        if not no_noun:
+        if expect_noun:
             if len(command) > len(typed_verb) + 1:
-                rest_of_command = command.split(typed_verb + ' ')[1]
-                for i in {**self._nouns, **self._directions}:
-                    if rest_of_command == i:
-                        noun = i
-                    else:
-                        for syn in {**self._nouns, **self._directions}[i]:
-                            if rest_of_command == syn:
-                                noun = i
-                if noun != '':
-                    parsed_command.append(noun)
+                noun_result = self.eat_noun(command, typed_verb)
+                if noun_result != '' and noun_result is not None:
+                    parsed_command.append(noun_result)
                 else:
+                    rest_of_command = command.split(typed_verb + ' ')[1]
                     print(f'I don\'t understand the noun "{rest_of_command}."')
                     return
+
+        print(parsed_command)
         return parsed_command
 
 

--- a/pag/parser.py
+++ b/pag/parser.py
@@ -87,6 +87,24 @@ class Parser:
         """
         Try to consume a verb.
         """
+        verb = ''
+        typed_verb = ''
+        for i in self._verbs:
+            if command.startswith(i + ' ') or command.strip() == i:
+                verb = i
+                typed_verb = i
+            if command.strip() == i:
+                expect_noun = False
+            else:
+                for syn in self._verbs[i]:
+                    if (command.startswith(syn + ' ') or
+                        command.strip() == syn):
+                        verb = i
+                        typed_verb = syn
+                    if command.strip() == syn:
+                        expect_noun = False
+
+        return verb, typed_verb
 
     def eat_noun(self, command, typed_verb):
         """
@@ -114,42 +132,23 @@ class Parser:
 
         parsed_command = []
         # command must start with a verb
-        expect_noun = True
-        verb = ''
-        typed_verb = ''
-        for i in self._verbs:
-            if command.startswith(i + ' ') or command.strip() == i:
-                verb = i
-                typed_verb = i
-            if command.strip() == i:
-                expect_noun = False
-            else:
-                for syn in self._verbs[i]:
-                    if (command.startswith(syn + ' ') or
-                        command.strip() == syn):
-                        verb = i
-                        typed_verb = syn
-                    if command.strip() == syn:
-                        expect_noun = False
+        verb, typed_verb = self.eat_verb(command)
         if verb != '':
             parsed_command.append(verb)
         else:
             print('What?')
             return
 
-
         # next is a noun
-        noun = ''
         rest_of_command = ''
-        if expect_noun:
-            if len(command) > len(typed_verb) + 1:
-                noun_result = self.eat_noun(command, typed_verb)
-                if noun_result != '' and noun_result is not None:
-                    parsed_command.append(noun_result)
-                else:
-                    rest_of_command = command.split(typed_verb + ' ')[1]
-                    print(f'I don\'t understand the noun "{rest_of_command}."')
-                    return
+        if len(command) > len(typed_verb) + 1:
+            noun_result = self.eat_noun(command, typed_verb)
+            if noun_result != '' and noun_result is not None:
+                parsed_command.append(noun_result)
+            else:
+                rest_of_command = command.split(typed_verb + ' ')[1]
+                print(f'I don\'t understand the noun "{rest_of_command}."')
+                return
 
         return parsed_command
 

--- a/pag/parser.py
+++ b/pag/parser.py
@@ -6,14 +6,19 @@ class Preprocessor:
     def __init__(self):
 
         self._directions = pag_words.directions
+        self._extras = pag_words.extras
 
 
     def supplement_words(self, words=None):
         """
         """
+        if words is not None:
 
-        if 'directions' in words:
-            self._directions = {**self._verbs, **words['directions']}
+            if 'extras' in words:
+                self._extras = {**self._extras, **words['extras']}
+
+            if 'directions' in words:
+                self._directions = {**self._verbs, **words['directions']}
 
 
     def prep(self, command):
@@ -33,12 +38,20 @@ class Preprocessor:
                     if command.strip() == syn:
                         toreturn = "go {}".format(i)
 
+        # remove extra words
+        split_cmd = toreturn.split(' ')
+        removing = [word for word in split_cmd if word in self._extras]
+        for word in removing:
+            split_cmd.remove(word)
+        toreturn = ' '.join(split_cmd)
+
         return toreturn
 
 
 class Parser:
     def __init__(self):
         pass
+        self._words = None
         self._verbs = pag_words.verbs
         self._nouns = pag_words.nouns
         self._extras = pag_words.extras
@@ -48,6 +61,8 @@ class Parser:
     def supplement_words(self, words=None):
         """
         """
+
+        self._words = words
 
         if words is not None:
             if 'verbs' in words:
@@ -88,15 +103,10 @@ class Parser:
 
 
         prep = Preprocessor()
+        prep.supplement_words(self._words)
 
         command = prep.prep(command)
 
-        # remove extra words
-        split_cmd = command.split(' ')
-        removing = [word for word in split_cmd if word in self._extras]
-        for word in removing:
-            split_cmd.remove(word)
-        command = ' '.join(split_cmd)
         parsed_command = []
         # command must start with a verb
         expect_noun = True

--- a/pag/parser.py
+++ b/pag/parser.py
@@ -2,83 +2,100 @@
 
 from pag import words as pag_words
 
+
+class Parser:
+    def __init__(self):
+        pass
+        self._verbs = pag_words.verbs
+        self._nouns = pag_words.nouns
+        self._extras = pag_words.extras
+        self._directions = pag_words.directions
+
+
+    def supplement_words(self, words=None):
+        """
+        """
+
+        if words is not None:
+            if 'verbs' in words:
+                self._verbs = {**self._verbs, **words['verbs']}
+
+            if 'nouns' in words:
+                self._nouns = {**self._nouns, **words['nouns']}
+
+            if 'extras' in words:
+                self._extras = {**self._extras, **words['extras']}
+
+            if 'directions' in words:
+                self._directions = {**self._verbs, **words['directions']}
+
+
+    def parse(self, command):
+
+        command = command.lower()
+        # remove extra words
+        split_cmd = command.split(' ')
+        removing = [word for word in split_cmd if word in self._extras]
+        for word in removing:
+            split_cmd.remove(word)
+        command = ' '.join(split_cmd)
+        parsed_command = []
+        # command must start with a verb
+        no_noun = False
+        verb = ''
+        typed_verb = ''
+        for i in self._verbs:
+            if command.startswith(i + ' ') or command.strip() == i:
+                verb = i
+                typed_verb = i
+            if command.strip() == i:
+                no_noun = True
+            else:
+                for syn in self._verbs[i]:
+                    if (command.startswith(syn + ' ') or
+                        command.strip() == syn):
+                        verb = i
+                        typed_verb = syn
+                    if command.strip() == syn:
+                        no_noun = True
+        if verb != '':
+            parsed_command.append(verb)
+        else:
+            # See if command is only a direction
+            for i in self._directions:
+                if command.strip() == i:
+                    # Return Verb, Noun
+                    return [None, i]
+                else:
+                    for syn in self._directions[i]:
+                        if command.strip() == syn:
+                            return [None, i]
+            print('What?')
+            return
+        # next is a noun
+        noun = ''
+        rest_of_command = ''
+        if not no_noun:
+            if len(command) > len(typed_verb) + 1:
+                rest_of_command = command.split(typed_verb + ' ')[1]
+                for i in {**self._nouns, **self._directions}:
+                    if rest_of_command == i:
+                        noun = i
+                    else:
+                        for syn in {**self._nouns, **self._directions}[i]:
+                            if rest_of_command == syn:
+                                noun = i
+                if noun != '':
+                    parsed_command.append(noun)
+                else:
+                    print(f'I don\'t understand the noun "{rest_of_command}."')
+                    return
+        return parsed_command
+
+
+
 def parse_command(command, words=None):
 
-    verbs = pag_words.verbs
-    nouns = pag_words.nouns
-    extras = pag_words.extras
-    directions = pag_words.directions
-
-    if words is not None:
-        if 'verbs' in words:
-            verbs = {**verbs, **words['verbs']}
-
-        if 'nouns' in words:
-            nouns = {**nouns, **words['nouns']}
-
-        if 'extras' in words:
-            extras = {**extras, **words['extras']}
-
-        if 'directions' in words:
-            directions = {**verbs, **words['directions']}
-
-
-    command = command.lower()
-    # remove extra words
-    split_cmd = command.split(' ')
-    removing = [word for word in split_cmd if word in extras]
-    for word in removing:
-        split_cmd.remove(word)
-    command = ' '.join(split_cmd)
-    parsed_command = []
-    # command must start with a verb
-    no_noun = False
-    verb = ''
-    typed_verb = ''
-    for i in verbs:
-        if command.startswith(i + ' ') or command.strip() == i:
-            verb = i
-            typed_verb = i
-        if command.strip() == i:
-            no_noun = True
-        else:
-            for syn in verbs[i]:
-                if (command.startswith(syn + ' ') or
-                    command.strip() == syn):
-                    verb = i
-                    typed_verb = syn
-                if command.strip() == syn:
-                    no_noun = True
-    if verb != '':
-        parsed_command.append(verb)
-    else:
-        # See if command is only a direction
-        for i in directions:
-            if command.strip() == i:
-                # Return Verb, Noun
-                return [None, i]
-            else:
-                for syn in directions[i]:
-                    if command.strip() == syn:
-                        return [None, i]
-        print('What?')
-        return
-    # next is a noun
-    noun = ''
-    rest_of_command = ''
-    if not no_noun:
-        if len(command) > len(typed_verb) + 1:
-            rest_of_command = command.split(typed_verb + ' ')[1]
-            for i in {**nouns, **directions}:
-                if rest_of_command == i:
-                    noun = i
-                else:
-                    for syn in {**nouns, **directions}[i]:
-                        if rest_of_command == syn:
-                            noun = i
-            if noun != '':
-                parsed_command.append(noun)
-            else:
-                print(f'I don\'t understand the noun "{rest_of_command}."')
-                return
-    return parsed_command
+    parser = Parser()
+    parser.supplement_words(words)
+    return parser.parse(command)

--- a/tests.py
+++ b/tests.py
@@ -69,8 +69,18 @@ class TestWords(unittest.TestCase):
 class TestParser(unittest.TestCase):
 
     def test_go_direction(self):
-        string = 'go south'
-        self.assertEqual(pag.parser.parse_command(string), ['go', 'south'])
+        str1 = 's'
+        str2 = 'south'
+        str3 = 'go s'
+        str4 = 'go south'
+        expected = ['go', 'south']
+        self.assertEqual(pag.parser.parse_command(str1), expected)
+        self.assertEqual(pag.parser.parse_command(str2), expected)
+        self.assertEqual(pag.parser.parse_command(str3), expected)
+        self.assertEqual(pag.parser.parse_command(str4), expected)
+
+
+        self.assertEqual(pag.parser.parse_command("n"), ['go', 'north'])
 
     def test_take(self):
         string = 'take sword'

--- a/tests.py
+++ b/tests.py
@@ -90,6 +90,26 @@ class TestParser(unittest.TestCase):
         self.assertEqual(pag.parser.parse_command(str1), expected)
         self.assertEqual(pag.parser.parse_command(str2), expected)
 
+    def test_noun_management(self):
+        """
+        Noun parsing.
+        """
+        str1 = "look" ; exp1 = ['look']
+        str2 = "look fist" ; exp2 = ['look', 'fist']
+        str3 = "look look" ; exp3 = None # & printed error 'I don't understand the noun "look."'
+        str4 = "look xixt" ; exp4 = None # & printed error 'I don't understand the noun "xixt."'
+        str5 = "look fi st" ; exp5 = None # & printed error 'I don't understand the noun "fi st."'
+        str6 = "look toilet paper" ; exp6 = ['look', 'toilet paper']
+        str7 = "look fist fist " ; exp7 = None # & printed error 'I don't understand the noun "fist fist."'
+
+        self.assertEqual(pag.parser.parse_command(str1), exp1)
+        self.assertEqual(pag.parser.parse_command(str2), exp2)
+        self.assertEqual(pag.parser.parse_command(str3), exp3)
+        self.assertEqual(pag.parser.parse_command(str4), exp4)
+        self.assertEqual(pag.parser.parse_command(str5), exp5)
+        self.assertEqual(pag.parser.parse_command(str6), exp6)
+        self.assertEqual(pag.parser.parse_command(str7), exp7)
+
     def test_substitute_synonyms(self):
         """
         Verify that synonyms are replaced with their canonical representation.

--- a/tests.py
+++ b/tests.py
@@ -100,6 +100,26 @@ class TestParser(unittest.TestCase):
         self.assertEqual(pag.parser.parse_command(str1), expected)
         self.assertEqual(pag.parser.parse_command(str2), expected)
 
+    def test_handle_whitespace(self):
+
+        # Empty command inputs.
+        self.assertEqual(pag.parser.parse_command(""), None)
+        self.assertEqual(pag.parser.parse_command(" "), None)
+        self.assertEqual(pag.parser.parse_command("    "), None)
+
+
+        # Command inputs with extra whitespace. Can't handle whitespace in the middle of words though.
+        expected = ['look', 'toilet paper']
+
+        strings = [ "look toilet paper  ",
+                    " look toilet   paper  ",
+                    "    look   toilet   paper  ",
+                    " look toilet\tpaper  ",]
+
+        for string in strings:
+            self.assertEqual(pag.parser.parse_command(string), expected)
+
+
     def test_noun_management(self):
         """
         Noun parsing.


### PR DESCRIPTION
Doesn't completely do everything discussed in #21.

Directional commands are substituted in preprocessor, but synonym search loops like `for syn in {**self._nouns, **self._directions}[i]:` remain in the parser.

Grammar is mostly unchanged for now.
